### PR TITLE
Add additional reference tags for "cleveref"-style support

### DIFF
--- a/lib/jekyll/sheafy/references.rb
+++ b/lib/jekyll/sheafy/references.rb
@@ -1,7 +1,7 @@
 module Jekyll
   module Sheafy
     module References
-      RE_REF_TAG = /{%\s*ref (?<slug>.+?)\s*%}/
+      RE_REF_TAG = /{%\s*[cp]?ref (?<slug>.+?)\s*%}/
       REFERRERS_KEY = "referrers"
 
       def self.process(nodes_index)

--- a/spec/jekyll/sheafy/references_spec.rb
+++ b/spec/jekyll/sheafy/references_spec.rb
@@ -19,6 +19,15 @@ describe Jekyll::Sheafy::References do
       expect(subject.scan_references(node)).to eq(["0001", "0002", "0003"])
     end
 
+    it "detects pref and cref" do
+      node = Node.new(content: <<~CONTENT)
+        {% ref 0001 %}
+        {% pref 0002 %}
+        {% cref 0003 %}
+      CONTENT
+      expect(subject.scan_references(node)).to eq(["0001", "0002", "0003"])
+    end
+
     it "keeps duplicates" do
       node = Node.new(content: <<~CONTENT)
         {% ref 0001 %}


### PR DESCRIPTION
I am working on richer support for references in my book (see https://github.com/jonsterling/math/pull/43); the idea is to have a `cref` tag that behaves like the LaTeX `cleveref` package, writing something like `Theorem 3.2*a [000X]` rather than just `[000X]`; I also add a `pref` tag for a parenthetical reference.

Unfortunately, in doing so I broke the support for computing the referrers of a given node which is built into sheafy. So in this PR I have extended the code (and the tests) to support these new tags.

However, I am thinking that it may be a better long-term solution to simply make the ref tag regex customizable as part of the sheafy configuration. What do you think?